### PR TITLE
Add test-execution-name input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   url-replacements:
     required: false
     description: 'URL replacements e.g. http://example.com=http://example.net,http://example.org=http://example.net'
+  test-execution-name:
+    required: false
+    description: 'Name of the test execution (not supported by test plan executions)'
   browser:
     required: false
     description: 'Browser for running the test scenario (not supported by test plan executions)'
@@ -51,6 +54,7 @@ runs:
         INPUT_WAIT: ${{ inputs.wait }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_URL_REPLACEMENTS: ${{ inputs.url-replacements }}
+        INPUT_TEST_EXECUTION_NAME: ${{ inputs.test-execution-name }}
         INPUT_BROWSER: ${{ inputs.browser }}
         INPUT_DEVICE: ${{ inputs.device }}
         INPUT_DEVICE_TYPE: ${{ inputs.device-type }}

--- a/script.bash
+++ b/script.bash
@@ -28,6 +28,10 @@ if ! [ -z "${INPUT_URL_REPLACEMENTS}" ]; then
   done
 fi
 
+if ! [ -z "${INPUT_TEST_EXECUTION_NAME}" ]; then
+  add_args "--name=${INPUT_TEST_EXECUTION_NAME}"
+fi
+
 if ! [ -z "${INPUT_BROWSER}" ]; then
   add_args "--browser=${INPUT_BROWSER}"
 fi

--- a/test.bash
+++ b/test.bash
@@ -28,10 +28,11 @@ function t() {
   export INPUT_WAIT=true
   export INPUT_TIMEOUT=300
   export INPUT_URL_REPLACEMENTS=a,b
+  export INPUT_TEST_EXECUTION_NAME=a
   export INPUT_BROWSER=a
   export INPUT_DEVICE=a
   export INPUT_DEVICE_TYPE=a
   export INPUT_OS=a
   export INPUT_OS_VERSION=a
-  t "autify web test run a --wait -t=300 -r=a -r=b --browser=a --device=a --device-type=a --os=a --os-version=a"
+  t "autify web test run a --wait -t=300 -r=a -r=b --name=a --browser=a --device=a --device-type=a --os=a --os-version=a"
 }


### PR DESCRIPTION
We missed to add `--name` parameter support. `name` is too general
so that we name it more verbose way.