### PR TITLE
Add `autify-connect-key`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   os-version:
     required: false
     description: 'OS version for running the test scenario (not supported by test plan executions)'
+  autify-connect-key:
+    required: false
+    description: 'Name of the Autify Connect Key (not supported by test plan executions)'
   autify-path:
     required: false
     default: 'autify'
@@ -72,4 +75,5 @@ runs:
         INPUT_DEVICE_TYPE: ${{ inputs.device-type }}
         INPUT_OS: ${{ inputs.os }}
         INPUT_OS_VERSION: ${{ inputs.os-version }}
+        INPUT_AUTIFY_CONNECT_KEY: ${{ inputs.autify-connect-key }}
         INPUT_AUTIFY_PATH: ${{ inputs.autify-path }}

--- a/script.bash
+++ b/script.bash
@@ -65,6 +65,10 @@ if [ -n "${INPUT_OS_VERSION}" ]; then
   add_args "--os-version=${INPUT_OS_VERSION}"
 fi
 
+if [ -n "${INPUT_AUTIFY_CONNECT_KEY}" ]; then
+  add_args "--autify-connect-key=${INPUT_AUTIFY_CONNECT_KEY}"
+fi
+
 OUTPUT=$(mktemp)
 AUTIFY_WEB_ACCESS_TOKEN=${INPUT_ACCESS_TOKEN} ${AUTIFY} web test run "${ARGS[@]}" 2>&1 | tee "$OUTPUT"
 exit_code=${PIPESTATUS[0]}

--- a/test/test.bash
+++ b/test/test.bash
@@ -15,6 +15,7 @@ function before() {
   unset INPUT_DEVICE_TYPE
   unset INPUT_OS
   unset INPUT_OS_VERSION
+  unset INPUT_AUTIFY_CONNECT_KEY
   echo "=== TEST ==="
 }
 
@@ -105,18 +106,19 @@ function test_output() {
   export INPUT_AUTIFY_TEST_URL=a
   export INPUT_WAIT=true
   export INPUT_TIMEOUT=300
-  export INPUT_URL_REPLACEMENTS=a,b
-  export INPUT_TEST_EXECUTION_NAME=a
-  export INPUT_BROWSER=a
-  export INPUT_DEVICE=a
-  export INPUT_DEVICE_TYPE=a
-  export INPUT_OS=a
-  export INPUT_OS_VERSION=a
-  test_command "autify web test run a --wait -t=300 -r=a -r=b --name=a --browser=a --device=a --device-type=a --os=a --os-version=a"
+  export INPUT_URL_REPLACEMENTS=b1,b2
+  export INPUT_TEST_EXECUTION_NAME=c
+  export INPUT_BROWSER=d
+  export INPUT_DEVICE=e
+  export INPUT_DEVICE_TYPE=f
+  export INPUT_OS=g
+  export INPUT_OS_VERSION=h
+  export INPUT_AUTIFY_CONNECT_KEY=i
+  test_command "autify web test run a --wait -t=300 -r=b1 -r=b2 --name=c --browser=d --device=e --device-type=f --os=g --os-version=h --autify-connect-key=i"
   test_code 0
   test_log
   test_output exit-code "0"
-  test_output log "autify web test run a --wait -t=300 -r=a -r=b --name=a --browser=a --device=a --device-type=a --os=a --os-version=a\n$(cat "$log_file")"
+  test_output log "autify web test run a --wait -t=300 -r=b1 -r=b2 --name=c --browser=d --device=e --device-type=f --os=g --os-version=h --autify-connect-key=i\n$(cat "$log_file")"
   test_output result-url "https://result"
 }
 


### PR DESCRIPTION
Autify CLI supports `--autify-connect-key` for `web test run` now.
This commit adds its support to the GitHub Actions.

Also, minor update for the unit test to make it more reliable.