### PR TITLE
Add more options and misc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 # Run test on Autify for Web
+
 Run a test scenario or test plan on Autify for Web.
 
 See our official documentation to get started: https://help.autify.com/docs/github-actions-integration
@@ -10,6 +11,7 @@ See our official documentation to get started: https://help.autify.com/docs/gith
 ## Usage
 
 ### Run a test scenario or test plan
+
 ```yaml
 - uses: autifyhq/actions-web-test-run@v1
   with:
@@ -20,6 +22,7 @@ See our official documentation to get started: https://help.autify.com/docs/gith
 This will succeed immediately once the test is started but won't wait the finish of the test.
 
 ### Run and wait a test scenario or test plan
+
 ```yaml
 - uses: autifyhq/actions-web-test-run@v1
   with:
@@ -34,56 +37,69 @@ This will keep running the action until the test finishes or times out.
 **Note: This will consume your GitHub Actions hosted runner's minutes. Be careful when extending the timeout value.**
 
 ## Options
+
 ```yaml
-  access-token:
-    required: true
-    description: 'Access token of Autify for Web.'
-  autify-test-url:
-    required: true
-    description: 'URL of a test scenario or test plan e.g. https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>'
-  wait:
-    required: false
-    default: 'false'
-    description: 'When true, the action waits until the test finishes.'
-  timeout:
-    required: false
-    description: 'Timeout seconds when waiting.'
-  url-replacements:
-    required: false
-    description: 'URL replacements e.g. http://example.com=http://example.net,http://example.org=http://example.net'
-  test-execution-name:
-    required: false
-    description: 'Name of the test execution (not supported by test plan executions)'
-  browser:
-    required: false
-    description: 'Browser for running the test scenario (not supported by test plan executions)'
-  device:
-    required: false
-    description: 'Device for running the test scenario (not supported by test plan executions)'
-  device-type:
-    required: false
-    description: 'Device type for running the test scenario (not supported by test plan executions)'
-  os:
-    required: false
-    description: 'OS for running the test scenario (not supported by test plan executions)'
-  os-version:
-    required: false
-    description: 'OS version for running the test scenario (not supported by test plan executions)'
-  autify-connect:
-    required: false
-    description: 'Name of the Autify Connect Access Point (not supported by test plan executions)'
-  autify-path:
-    required: false
-    default: 'autify'
-    description: 'A path to `autify`. If set, this action will not install autify-cli.'
+access-token:
+  required: true
+  description: "Access token of Autify for Web."
+autify-test-url:
+  required: true
+  description: "URL of a test scenario or test plan e.g. https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>"
+wait:
+  required: false
+  default: "false"
+  description: "When true, the action waits until the test finishes."
+timeout:
+  required: false
+  description: "Timeout seconds when waiting."
+url-replacements:
+  required: false
+  description: "URL replacements e.g. http://example.com=http://example.net,http://example.org=http://example.net"
+max-retry-count:
+  required: false
+  description: "Maximum retry count while waiting. The command can take up to `timeout * (max-retry-count + 1)`. Only effective with `wait`"
+test-execution-name:
+  required: false
+  description: "Name of the test execution (not supported by test plan executions)"
+browser:
+  required: false
+  description: "Browser for running the test scenario (not supported by test plan executions)"
+device:
+  required: false
+  description: "Device for running the test scenario (not supported by test plan executions)"
+device-type:
+  required: false
+  description: "Device type for running the test scenario (not supported by test plan executions)"
+os:
+  required: false
+  description: "OS for running the test scenario (not supported by test plan executions)"
+os-version:
+  required: false
+  description: "OS version for running the test scenario (not supported by test plan executions)"
+autify-connect:
+  required: false
+  description: "Name of the Autify Connect Access Point (not supported by test plan executions)"
+autify-connect-client:
+  required: false
+  description: "When true, start Autify Connect Client. (not supported by test plan executions)"
+  default: "false"
+autify-path:
+  required: false
+  default: "autify"
+  description: "A path to `autify` which will be used to invoke Autify CLI internally. Default is searching from PATH."
+autify-cli-installer-url:
+  required: false
+  default: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash"
+  description: "Autify CLI installer URL"
 ```
 
 ## Outputs
+
 ```yaml
-  exit-code:
-    description: 'Exit code of autify-cli. 0 means succeeded.'
-  log:
-    description: 'Log of stdout and stderr.'
-  result-url:
-    description: 'Test result URL on Autify for Web'
+exit-code:
+  description: "Exit code of autify-cli. 0 means succeeded."
+log:
+  description: "Log of stdout and stderr."
+result-url:
+  description: "Test result URL on Autify for Web"
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   url-replacements:
     required: false
     description: 'URL replacements e.g. http://example.com=http://example.net,http://example.org=http://example.net'
+  max-retry-count:
+    required: false
+    description: 'Maximum retry count while waiting. The command can take up to `timeout * (max-retry-count + 1)`. Only effective with `wait`'
   test-execution-name:
     required: false
     description: 'Name of the test execution (not supported by test plan executions)'
@@ -39,14 +42,18 @@ inputs:
   autify-connect:
     required: false
     description: 'Name of the Autify Connect Access Point (not supported by test plan executions)'
+  autify-connect-client:
+    required: false
+    description: 'When true, start Autify Connect Client. (not supported by test plan executions)'
+    default: 'false'
   autify-path:
     required: false
     default: 'autify'
     description: 'A path to `autify` which will be used to invoke Autify CLI internally. Default is searching from PATH.'
   autify-cli-installer-url:
     required: false
-    description: 'Autify CLI installer URL'
     default: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash"
+    description: 'Autify CLI installer URL'
 
 outputs:
   exit-code:
@@ -74,6 +81,7 @@ runs:
         INPUT_WAIT: ${{ inputs.wait }}
         INPUT_TIMEOUT: ${{ inputs.timeout }}
         INPUT_URL_REPLACEMENTS: ${{ inputs.url-replacements }}
+        INPUT_MAX_RETRY_COUNT: ${{ inputs.max-retry-count }}
         INPUT_TEST_EXECUTION_NAME: ${{ inputs.test-execution-name }}
         INPUT_BROWSER: ${{ inputs.browser }}
         INPUT_DEVICE: ${{ inputs.device }}
@@ -81,4 +89,5 @@ runs:
         INPUT_OS: ${{ inputs.os }}
         INPUT_OS_VERSION: ${{ inputs.os-version }}
         INPUT_AUTIFY_CONNECT: ${{ inputs.autify-connect }}
+        INPUT_AUTIFY_CONNECT_CLIENT: ${{ inputs.autify-connect-client }}
         INPUT_AUTIFY_PATH: ${{ inputs.autify-path }}

--- a/test/test.bash
+++ b/test/test.bash
@@ -9,6 +9,7 @@ function before() {
   unset INPUT_WAIT
   unset INPUT_TIMEOUT
   unset INPUT_URL_REPLACEMENTS
+  unset INPUT_MAX_RETRY_COUNT
   unset INPUT_TEST_EXECUTION_NAME
   unset INPUT_BROWSER
   unset INPUT_DEVICE
@@ -16,6 +17,7 @@ function before() {
   unset INPUT_OS
   unset INPUT_OS_VERSION
   unset INPUT_AUTIFY_CONNECT
+  unset INPUT_AUTIFY_CONNECT_CLIENT
   echo "=== TEST ==="
 }
 
@@ -107,18 +109,20 @@ function test_output() {
   export INPUT_WAIT=true
   export INPUT_TIMEOUT=300
   export INPUT_URL_REPLACEMENTS=b1,b2
-  export INPUT_TEST_EXECUTION_NAME=c
-  export INPUT_BROWSER=d
-  export INPUT_DEVICE=e
-  export INPUT_DEVICE_TYPE=f
-  export INPUT_OS=g
-  export INPUT_OS_VERSION=h
-  export INPUT_AUTIFY_CONNECT=i
-  test_command "autify web test run a --wait -t=300 -r=b1 -r=b2 --name=c --browser=d --device=e --device-type=f --os=g --os-version=h --autify-connect=i"
+  export INPUT_MAX_RETRY_COUNT=c
+  export INPUT_TEST_EXECUTION_NAME=d
+  export INPUT_BROWSER=e
+  export INPUT_DEVICE=f
+  export INPUT_DEVICE_TYPE=g
+  export INPUT_OS=h
+  export INPUT_OS_VERSION=i
+  export INPUT_AUTIFY_CONNECT=j
+  export INPUT_AUTIFY_CONNECT_CLIENT=true
+  test_command "autify web test run a --wait -t=300 -r=b1 -r=b2 --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client"
   test_code 0
   test_log
   test_output exit-code "0"
-  test_output log "autify web test run a --wait -t=300 -r=b1 -r=b2 --name=c --browser=d --device=e --device-type=f --os=g --os-version=h --autify-connect=i\n$(cat "$log_file")"
+  test_output log "autify web test run a --wait -t=300 -r=b1 -r=b2 --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client\n$(cat "$log_file")"
   test_output result-url "https://result"
 }
 


### PR DESCRIPTION
Adding more options recently supported by Autify CLI i.e. `max-retry-count` and `autify-connect-client`.

Also, updating misc such as trapping exit code.