### PR TITLE
Support Autify Connect with test plan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
+
       - id: web-test-run
         uses: ./
         with:
@@ -69,6 +70,40 @@ jobs:
       - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.log }}" | grep "Autify Connect Client is ready!"
       - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.log }}" | grep "Test passed!"
       - run: echo "${{ steps.web-test-run-wait-autify-connect-client.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
+
+      - id: web-test-run-test-plan
+        uses: ./
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-test-url: https://app.autify.com/projects/0000/test_plans/0000
+      - run: test "${{ steps.web-test-run-test-plan.outputs.exit-code }}" = 0
+      - run: echo "${{ steps.web-test-run-test-plan.outputs.log }}" | grep "Successfully started"
+      - run: echo "${{ steps.web-test-run-test-plan.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
+
+      - id: web-test-run-test-plan-wait
+        uses: ./
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-test-url: https://app.autify.com/projects/0000/test_plans/0000
+          wait: true
+      - run: test "${{ steps.web-test-run-test-plan-wait.outputs.exit-code }}" = 0
+      - run: echo "${{ steps.web-test-run-test-plan-wait.outputs.log }}" | grep "Test passed!"
+      - run: echo "${{ steps.web-test-run-test-plan-wait.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
+
+      - id: web-test-run-test-plan-wait-autify-connect-client
+        uses: ./
+        with:
+          access-token: token
+          autify-path: autify-with-proxy
+          autify-test-url: https://app.autify.com/projects/0000/test_plans/0000
+          wait: true
+          autify-connect-client: true
+      - run: test "${{ steps.web-test-run-test-plan-wait-autify-connect-client.outputs.exit-code }}" = 0
+      - run: echo "${{ steps.web-test-run-test-plan-wait-autify-connect-client.outputs.log }}" | grep "Autify Connect Client is ready!"
+      - run: echo "${{ steps.web-test-run-test-plan-wait-autify-connect-client.outputs.log }}" | grep "Test passed!"
+      - run: echo "${{ steps.web-test-run-test-plan-wait-autify-connect-client.outputs.result-url }}" | grep -E 'https://app.autify.com/projects/[[:digit:]]+/'
 
       - id: failed
         uses: ./

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ os-version:
   description: "OS version for running the test scenario (not supported by test plan executions)"
 autify-connect:
   required: false
-  description: "Name of the Autify Connect Access Point (not supported by test plan executions)"
+  description: "Name of the Autify Connect Access Point"
 autify-connect-client:
   required: false
-  description: "When true, start Autify Connect Client. (not supported by test plan executions)"
+  description: "When true, start Autify Connect Client"
   default: "false"
 autify-path:
   required: false

--- a/action.yml
+++ b/action.yml
@@ -41,10 +41,10 @@ inputs:
     description: 'OS version for running the test scenario (not supported by test plan executions)'
   autify-connect:
     required: false
-    description: 'Name of the Autify Connect Access Point (not supported by test plan executions)'
+    description: 'Name of the Autify Connect Access Point'
   autify-connect-client:
     required: false
-    description: 'When true, start Autify Connect Client. (not supported by test plan executions)'
+    description: 'When true, start Autify Connect Client'
     default: 'false'
   autify-path:
     required: false


### PR DESCRIPTION
Since 0.12.0 of Autify CLI, we support Autify Connect configuration for test plan execution.

This commit adds support for it on this action as well.