### PR TITLE
Use delimiter for outputting multiline strings

### DIFF
--- a/script.bash
+++ b/script.bash
@@ -87,13 +87,13 @@ OUTPUT=$(mktemp)
 AUTIFY_WEB_ACCESS_TOKEN=${INPUT_ACCESS_TOKEN} ${AUTIFY} web test run "${ARGS[@]}" 2>&1 | tee "$OUTPUT"
 exit_code=${PIPESTATUS[0]}
 
-# Workaround to return multiline string as outputs
-# https://trstringer.com/github-actions-multiline-strings/
+# Output multiline strings
+# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 output=$(cat "$OUTPUT")
-output="${output//'%'/%25}"
-output="${output//$'\n'/%0A}"
-output="${output//$'\r'/%0D}"
-echo log="$output" >> "$GITHUB_OUTPUT"
+delimiter="$(openssl rand -hex 8)"
+echo "log<<${delimiter}" >> "${GITHUB_OUTPUT}"
+echo "${output}" >> "${GITHUB_OUTPUT}"
+echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
 result=$(grep "Successfully started" "$OUTPUT" | grep -Eo 'https://[^ ]+' | head -1)
 echo result-url="$result" >> "$GITHUB_OUTPUT"

--- a/script.bash
+++ b/script.bash
@@ -91,9 +91,11 @@ exit_code=${PIPESTATUS[0]}
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 output=$(cat "$OUTPUT")
 delimiter="$(openssl rand -hex 8)"
-echo "log<<${delimiter}" >> "${GITHUB_OUTPUT}"
-echo "${output}" >> "${GITHUB_OUTPUT}"
-echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+{
+  echo "log<<${delimiter}"
+  echo "${output}"
+  echo "${delimiter}"
+} >> "${GITHUB_OUTPUT}"
 
 result=$(grep "Successfully started" "$OUTPUT" | grep -Eo 'https://[^ ]+' | head -1)
 echo result-url="$result" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Multiple lines of logs are displayed without line breaks now.
The following links show that multiline strings output no longer needs to be escaped, and the best way is to use delimiter.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
https://github.com/marocchino/sticky-pull-request-comment/issues/837
https://github.com/orgs/community/discussions/26288#discussioncomment-3876281

<img width="1466" alt="スクリーンショット 2023-02-17 20 03 18" src="https://user-images.githubusercontent.com/20950925/219631764-592f4e89-9acc-4a63-8af0-d4bf41f677cd.png">

The comment output method is referring to following article.
https://help.autify.com/docs/en/integrate-with-code-review-process
And this is the yml to reproduce the problem. When you create a PR and comment on it, this job starts and the bot comments on the PR.
```
name: CI

on:
  issue_comment:
    types: [created, edited]

jobs:
  no_line_break_comment:
    runs-on: ubuntu-latest
    steps:
      - name: Run test on Autify for Web
        id: run
        uses: autifyhq/actions-web-test-run@v2
        with:
          access-token: ${{ secrets.AUTIFY_WEB_ACCESS_TOKEN }}
          autify-test-url: https://app.autify.com/projects/xxx/scenarios/xxxxxx
        continue-on-error: true

      - name: Comment Autify test result URL on the pull request
        if: ${{ steps.run.conclusion == 'success' }}
        uses: marocchino/sticky-pull-request-comment@v2
        with:
          number: ${{ github.event.issue.number }}
          message: |
            Autify test was started. Check ${{ steps.run.outputs.result-url }}
            ```
            ${{ steps.run.outputs.log }}
            ```

      - name: Comment failed to start Autify test on the pull request
        if: ${{ steps.run.conclusion == 'failure' }}
        uses: marocchino/sticky-pull-request-comment@v2
        with:
          number: ${{ github.event.issue.number }}
          message: |
            Autify test was failed to start.
            ```
            ${{ steps.run.outputs.log }}
            ```
```

