### PR TITLE
Update major tag automatically

### DIFF
--- a/.github/workflows/update-tag.yml
+++ b/.github/workflows/update-tag.yml
@@ -1,0 +1,23 @@
+name: Update tag
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  update-tag:
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get major version num and update tag
+        run: |
+          MAJOR=${GITHUB_REF_NAME%%.*}
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -fa ${MAJOR} -m "Update major version tag"
+          git push origin ${MAJOR} --force


### PR DESCRIPTION
When we release new version we also need to move `vX` tag.
I'd like to automate release workflow as possible as we can.

I tested this config works well on my test repo

https://github.com/mtsmfm/tag-test/actions/runs/4605920356/jobs/8138581066