### PR TITLE
Revert "Surround URL replacements option with quotes"

### DIFF
--- a/script.bash
+++ b/script.bash
@@ -37,7 +37,7 @@ fi
 if [ -n "${INPUT_URL_REPLACEMENTS}" ]; then
   IFS=',' read -ra URL_REPLACEMENTS <<< "${INPUT_URL_REPLACEMENTS}"
   for url_replacement in "${URL_REPLACEMENTS[@]}"; do
-    add_args "-r=\"${url_replacement}\""
+    add_args "-r=${url_replacement}"
   done
 fi
 

--- a/test/test.bash
+++ b/test/test.bash
@@ -133,7 +133,7 @@ function test_multiline_output() {
   export INPUT_AUTIFY_TEST_URL=a
   export INPUT_WAIT=true
   export INPUT_TIMEOUT=300
-  export INPUT_URL_REPLACEMENTS="https://example.com https://example.net,https://example.net https://example.com?foo=bar"
+  export INPUT_URL_REPLACEMENTS=b1,b2
   export INPUT_MAX_RETRY_COUNT=c
   export INPUT_TEST_EXECUTION_NAME=d
   export INPUT_BROWSER=e
@@ -144,11 +144,11 @@ function test_multiline_output() {
   export INPUT_AUTIFY_CONNECT=j
   export INPUT_AUTIFY_CONNECT_CLIENT=true
   export INPUT_AUTIFY_CONNECT_CLIENT_EXTRA_ARGUMENTS=k
-  test_command "autify web test run a --wait -t=300 -r=\"https://example.com https://example.net\" -r=\"https://example.net https://example.com?foo=bar\" --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k"
+  test_command "autify web test run a --wait -t=300 -r=b1 -r=b2 --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k"
   test_code 0
   test_log
   test_output exit-code "0"
-  test_multiline_output log "autify web test run a --wait -t=300 -r=\"https://example.com https://example.net\" -r=\"https://example.net https://example.com?foo=bar\" --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k\n$(cat "$log_file")"
+  test_multiline_output log "autify web test run a --wait -t=300 -r=b1 -r=b2 --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k\n$(cat "$log_file")"
   test_output result-url "https://result"
 }
 


### PR DESCRIPTION
Reverts autifyhq/actions-web-test-run#31

I've noticed currently v2 with url-replacements option doesn't work https://github.com/autifyhq/actions-web-test-run/pull/34

It seems its because of the difference between `autify` CLI and `autify-with-proxy` CLI, a wrapper command to use `autify` CLI within our CI for CI/CD integration plugins.

Both [`child_process.spawn`](https://github.com/autifyhq/autify-cli/blob/9d6be7c5ef6d3dd9709fddf23e6e5deea70136bf/integration-test/src/bin/autify-with-proxy.ts#L125) and [`"${ARGS[@]}"`](https://github.com/autifyhq/actions-web-test-run/blob/b42706737d6e3b005712184d00645db9782c7ee6/script.bash#L87) can have a whitespace within arg but currently `spawn` has `shell` option.
It parses `"` but `"${ARGS[@]}"` passes arguments as-is. As a result given argumen is like `--url-replacements "\"https://example.com https://example.net\""` on shell.

I'll remove the option https://github.com/autifyhq/autify-cli/pull/394