### PR TITLE
ci: pin github action with full-length commit hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: autifyhq/actions-setup-cli@v2
+    - uses: autifyhq/actions-setup-cli@62decfdbb7902d221d4865ae6170d5dbcd3c90db # v2.1.2
       with:
         shell-installer-url: ${{ inputs.autify-cli-installer-url }}
     - if: ${{ inputs.autify-connect-client == 'true' }}


### PR DESCRIPTION
In order to enable `Require actions to be pinned to a full-length commit SHA` setting, this diff is necessary.

Summary

  - Pin GitHub Actions to full-length commit hashes instead of version tags for improved security
  - Updated autifyhq/actions-setup-cli@v2 →  autifyhq/actions-setup-cli@62decfdbb7902d221d4865ae6170d5dbcd3c90db (v2.1.2)

  Why

  Pinning actions to commit hashes instead of version tags is a security best practice recommended by
  GitHub. Version tags can be moved to point to different commits, potentially introducing malicious
  code. Commit hashes are immutable and provide a stronger guarantee of the code being executed.